### PR TITLE
Added option for separate client IPs about proxy protocol use or not.

### DIFF
--- a/mod_proxy_protocol.c
+++ b/mod_proxy_protocol.c
@@ -1269,7 +1269,7 @@ static conftable proxy_protocol_conftab[] = {
   { "ProxyProtocolEngine",	set_proxyprotocolengine,	NULL },
   { "ProxyProtocolTimeout",	set_proxyprotocoltimeout,	NULL },
   { "ProxyProtocolVersion",	set_proxyprotocolversion,	NULL },
-  { "ProxyClientAddress",	set_proxyclientaddress,	NULL },
+  { "ProxyClientAddress",      set_proxyclientaddress,         NULL },
 
   { NULL }
 };

--- a/mod_proxy_protocol.c
+++ b/mod_proxy_protocol.c
@@ -1269,7 +1269,7 @@ static conftable proxy_protocol_conftab[] = {
   { "ProxyProtocolEngine",	set_proxyprotocolengine,	NULL },
   { "ProxyProtocolTimeout",	set_proxyprotocoltimeout,	NULL },
   { "ProxyProtocolVersion",	set_proxyprotocolversion,	NULL },
-  { "ProxyClientAddress",      set_proxyclientaddress,         NULL },
+  { "ProxyClientAddress",     set_proxyclientaddress,         NULL },
 
   { NULL }
 };

--- a/mod_proxy_protocol.c
+++ b/mod_proxy_protocol.c
@@ -1024,16 +1024,16 @@ char *check_ip_valid(char *address) {
   int i = 0;
 
   for (i = 0; i < len; i++) {
-      if (ip[i] < '0' || ip[i] > '9') {
-          if (ip[i] == '.' && nNumCount > 0) {
+    if (ip[i] < '0' || ip[i] > '9') {
+      if (ip[i] == '.' && nNumCount > 0) {
         ++nDotCount;
         nNumCount = 0;
       } else {
-              return NULL;
+        return NULL;
       }
     } else {
       if (++nNumCount > 3) {
-            return NULL;
+        return NULL;
       }
     }
   }
@@ -1058,8 +1058,8 @@ static int check_proxy_client(char *conf_addr, char *remote_ip) {
   unsigned int remoteIpMasking = ipToui(remote_ip) & maskAsUInt;
 
   if (confIpMasking == remoteIpMasking) {
-        return TRUE;
-      }
+    return TRUE;
+  }
 
   return FALSE;
 }


### PR DESCRIPTION
Will add option for separate client IPs about proxy protocol use or not.

So, can use both clients that use the proxy protocol(pre setted) and do not on one proftpd server at the same time.

- Config example
```Vim
<IfModule mod_proxy_protocol.c>
  ProxyProtocolEngine on
  ProxyProtocolTimeout 3sec

  # can add more parameter
  ProxyClientAddress 192.168.18.33/24 192.168.33.2 192.168.33.1/31
</IfModule>
```

